### PR TITLE
Fix small typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ For $\frac{df}{dx}$ (again below), we move to a slice of a curve of a specific v
 
 Ok, so now that you understand the slide, slide, nudge, maybe you can understand this little shortcut that we can pull.  For any multivariable function, the variables that you are **not** taking the derivative with respect to, can just be treated as a constant.
 
-For example, with our function of $f(x, y) = y*x^2 $, when taking the partial derivative $\frac{df}{dy}f(x, y)$, we treat all values of $y$ as a constant.  Let's do it:
+For example, with our function of $f(x, y) = y*x^2 $, when taking the partial derivative $\frac{df}{dy}f(x, y)$, we treat all values of $x$ as a constant.  Let's do it:
 
 
 $$\frac{df}{dy}f(x,y) =  \frac{df}{dy}(y) * x^2 = 1*x^2 = x^2$$

--- a/index.ipynb
+++ b/index.ipynb
@@ -350,7 +350,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For example, with our function of $f(x, y) = y*x^2 $, when taking the partial derivative $\\frac{df}{dy}f(x, y)$, we treat all values of $y$ as a constant.  Let's do it:\n",
+    "For example, with our function of $f(x, y) = y*x^2 $, when taking the partial derivative $\\frac{df}{dy}f(x, y)$, we treat all values of $x$ as a constant.  Let's do it:\n",
     "\n",
     "\n",
     "$$\\frac{df}{dy}f(x,y) =  \\frac{df}{dy}(y) * x^2 = 1*x^2 = x^2$$"
@@ -433,7 +433,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.6.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
A student brought up there was a typo in this lab.  

![screen shot 2018-12-23 at 11 03 43 am](https://user-images.githubusercontent.com/22510132/50385876-78a41a80-06a2-11e9-87ea-5ab697f03021.png)

It currently says - when taking the partial derivative with respect to y, we treat all values of **y** as a constant 
It should say - when taking the partial derivative with respect to y, we should treat all values of **x** as a constant

I have updated this: 

![screen shot 2018-12-23 at 10 55 49 am](https://user-images.githubusercontent.com/22510132/50385889-b7d26b80-06a2-11e9-99ee-7c24ef980b97.png)
